### PR TITLE
Correct a bug occurring when the underlying file object is filling very ...

### DIFF
--- a/gzipstream/gzipstreamfile.py
+++ b/gzipstream/gzipstreamfile.py
@@ -22,7 +22,7 @@ class _GzipStreamFile(object):
     # TODO: Update this to use unconsumed_tail and a StringIO buffer
     # http://docs.python.org/2/library/zlib.html#zlib.Decompress.unconsumed_tail
     # Check if we need to start a new decoder
-    if self.decoder and self.decoder.unused_data:
+    while self.decoder and self.decoder.unused_data:
       self.restart_decoder()
     # Use unused data first
     if len(self.unused_buffer) > size:


### PR DESCRIPTION
...fast.

It is possible that « unused_raw » contains more than one end of stream and start of another. We need to restart the decoder while there are unused data at the end.

This caused a strange bug when using that to stream a commoncrawl archive on my server with a good bandwidth, that don't happened on my test computer :
zlib.error: Error -3 while decompressing: incorrect header check (in restart_decoder).
