### PR TITLE
Python 2.6 support

### DIFF
--- a/gzipstream/gzipstreamfile.py
+++ b/gzipstream/gzipstreamfile.py
@@ -55,6 +55,10 @@ class _GzipStreamFile(object):
     # io.BufferedReader needs us to appear readable
     return True
 
+  def _checkReadable(self):
+    # similar to readable(), needed for python 2.6
+    return True
+
 
 class GzipStreamFile(io.BufferedReader):
   def __init__(self, stream):


### PR DESCRIPTION
Hey, this is a small change that lets gzipstreamfile work with python2.6
I haven't used this in production yet, but the example test now works with 2.6 with this patch
